### PR TITLE
Added Verify Email Function on PDO

### DIFF
--- a/src/OAuth2/Storage/Pdo.php
+++ b/src/OAuth2/Storage/Pdo.php
@@ -647,6 +647,29 @@ class Pdo implements
     }
     
     /**
+     * Verify a user email
+     *
+     * @param integer $id
+     * @return void
+     */
+    public function verifyUserEmail($id) {
+
+        if(!isset($id)){
+            throw new InvalidArgumentException("ID is not set"); 
+        }
+
+        $isEmailVerified = 1;
+
+        $stmt = $this->db->prepare(sprintf('UPDATE %S SET email_verified = :is_email_verified WHERE id=:id', $this->config['user_table']));
+
+        $stmt->bindParam(':is_email_verified', $isEmailVerified);
+        $stmt->bindParam(':id', $id);
+
+        return $stmt->execute;
+
+    }
+    
+    /**
      * Deletes a user record on table
      *  
      * @param int $id User id in table

--- a/test/OAuth2/Storage/PdoTest.php
+++ b/test/OAuth2/Storage/PdoTest.php
@@ -38,4 +38,5 @@ class PdoTest extends BaseTest
         $config = array('username' => 'brent', 'password' => 'brentisaballer');
         $storage = new Pdo($config);
     }
+
 }


### PR DESCRIPTION
The verify email will take an id as input and set verified_email field
to true (1).

The relative tests are not implemented due to a missbehavior of the
test's suite.